### PR TITLE
Use nix.dev as the entry point to the Nix ecosystem

### DIFF
--- a/rfcs/1000-canonical-domain.md
+++ b/rfcs/1000-canonical-domain.md
@@ -11,7 +11,7 @@ related-issues: (will contain links to implementation PRs)
 # Summary
 [summary]: #summary
 
-Use `nix.dev` as the canonical domain for all official Nix projects.
+Use `nix.dev` as the entry point to the Nix ecosystem.
 
 # Motivation
 [motivation]: #motivation


### PR DESCRIPTION
There is no clear advantage I see in removing existing domains from our "brand namespace". To the contrary, there are several technical risks associated with it, and we'll have to maintain the old domains anyway.

There's also potential for confusion and drama. Human-readable links in the wild won't go away. And our brains are wired not to like things being taken away.

Instead let's make nix.dev the canonical *entry point* to the Nix user experience. Depending on how new users come to us, NixOS can either be seen as an advanced use case that requires ramp-up, or as the reason to deal with all this Nix stuff to begin with. That's not wrong, in fact it has many benefits.

This is a proposal to recommend one over the other as a first point of contact. The third option (the first being removing one entirely, which I reject with this change) is letting them live equivalently side by side. I think it's inferior to a clear recommendation, as there is a risk of (even only perceived) competition that we can't afford and that would just again produce confusion for beginners which I'm convinced we should avoid at all cost.