### PR TITLE
Nit: Motivation: nixos.org not confusing

### DIFF
--- a/rfcs/1000-canonical-domain.md
+++ b/rfcs/1000-canonical-domain.md
@@ -16,7 +16,7 @@ Use `nix.dev` as the canonical domain for all official Nix projects.
 # Motivation
 [motivation]: #motivation
 
-- `nixos.org` is incongruent since it's not just about NixOS.
+- The domain name nixos.org is not a close match for the website, which is about nix in general and not just about NixOS in particular
 - Having both `nixos.org` and `nix.dev` is not great because it looks like both can't be official (but they are)
 - `nixos.com` is an adult escort website, it would be better to distance ourselves a bit from it :)
 

--- a/rfcs/1000-canonical-domain.md
+++ b/rfcs/1000-canonical-domain.md
@@ -16,7 +16,7 @@ Use `nix.dev` as the canonical domain for all official Nix projects.
 # Motivation
 [motivation]: #motivation
 
-- `nixos.org` is confusing because it's not just about NixOS.
+- `nixos.org` is incongruent since it's not just about NixOS.
 - Having both `nixos.org` and `nix.dev` is not great because it looks like both can't be official (but they are)
 - `nixos.com` is an adult escort website, it would be better to distance ourselves a bit from it :)
 


### PR DESCRIPTION
I'd argue that the domain name itself isn't "confusing". The word "incongruent" would be more apt.

Perhaps a simpler phrasing is that "the domain name nixos.org is not a close match for the website, which is about nix in general and not just about NixOS in particular".